### PR TITLE
Wrong date format for the build-timestamp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ task toolDoc(type: Javadoc, dependsOn: classes ) {
 
     options.addStringOption("settings-dir", "src/main/resources/com/github/discvrseq/util/docTemplates");
     options.addStringOption("absolute-version", getVersion())
-    options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
+    options.addStringOption("build-timestamp", new Date().format("dd-MM-yyyy hh:mm:ss"))
 
     //gradle 6.x+ defaults to setting this true which breaks the barclay doclet
     options.noTimestamp(false)


### PR DESCRIPTION
Hi BimberLab.  I haven't done any work with your software yet, but I was planning to.  I saw this timestamp issue and thought I'd make a quick fix.

It seems the minutes are being used instead of the month
`05-33-2022 02:33:54.`
Here mm==33, and MM==01 (or should).

### **Please double check the documentation for this module as I'm not a Java developer.**